### PR TITLE
Remove unused pytz import

### DIFF
--- a/main_fastmcp.py
+++ b/main_fastmcp.py
@@ -3,7 +3,6 @@
 from fastmcp import FastMCP
 from datetime import datetime, timedelta
 # import datetime
-import pytz
 import os
 
 mcp = FastMCP(


### PR DESCRIPTION
## Summary
- clean up `main_fastmcp.py` by removing the unused `pytz` import

## Testing
- `python -m py_compile main_fastmcp.py`


------
https://chatgpt.com/codex/tasks/task_e_68413101ed58832fb578d0ad76454671